### PR TITLE
Add creation of python directories in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ src/main/java/io/prometheus/client/Metrics.java: metrics.proto
 python: python/prometheus/client/model/metrics_pb2.py
 
 python/prometheus/client/model/metrics_pb2.py: metrics.proto
+	mkdir -p python/prometheus/client/model
 	protoc $< --python_out=python/prometheus/client/model
 
 ruby:


### PR DESCRIPTION
Simple test:
make clean
make

Result:
protoc metrics.proto --python_out=python/prometheus/client/model
python/prometheus/client/model/: No such file or directory
make: *** [python/prometheus/client/model/metrics_pb2.py] Error 1

@beorn7 