### PR TITLE
Fix example in documentation

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -22,8 +22,10 @@ require 'prometheus/client/model'
 
 CONTENT_TYPE = 'application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited'
 
-stream = open('http://localhost:9090/metrics', 'Accept' => CONTENT_TYPE).read
-while family = Prometheus::Client::MetricFamily.read_delimited(stream)
+content = open('http://localhost:9100/metrics', 'Accept' => CONTENT_TYPE).read
+buffer = Beefcake::Buffer.new(content)
+
+while family = Prometheus::Client::MetricFamily.read_delimited(buffer)
   puts family
 end
 ```


### PR DESCRIPTION
The example in the documentation passes in the protobuf string to the `read_delimited` method which causes it to only parse the first item over and over again without progression.