### PR TITLE
Remove Install section from README.md

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -2,10 +2,6 @@
 
 Data model artifacts for the [Prometheus Ruby client][1].
 
-## Installation
-
-    gem install prometheus-client-model
-
 ## Usage
 
 Build the artifacts from the protobuf specification:


### PR DESCRIPTION
It points to a gem that doesn't actually contain the intended code. We
can add this back once the owner has updated the gem on rubygems.org.

@xtreme-andrew-su @grobie 
Fixes #29 (kind of…).
