### PR TITLE
Support Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/prometheus/client_model
+
+go 1.9
+
+require (
+	github.com/golang/protobuf v1.2.0
+	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
+golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Hello,

Please consider supporting Go Modules for tracking the version of the protobuf library used. There are several old issues about users having incorrect versions of the tool or how to handle versioning (eg. #26, #25, #24, #18, #10). A few of them the response was "we need an official solution before we standardize on versioning". Now that Prometheus has started using Modules, minimal support has been backported to all supported versions of Go and one older one, and they will be the default in Go 1.12 (next month sometime), I think that time may have finally come.

Note that I picked Go 1.9 as the minimum supported version because anything older than Go 1.9.7 won't read the `go.mod` file anyways, and the generated code appears to build under 1.9.7 just fine. I also pinned to the latest version of the protobuf library which appeared to generate the file correctly, but please let me know if there's a different version you prefer to use and I'll change the dependency.

Please consider merging this PR and then making a semver compatible tag that consumers of this library can pin to, eg. `v0.0.3`. Thank you for your time and consideration.